### PR TITLE
Fix errors when using relevel to change reference levels in standardsccs model call

### DIFF
--- a/R/standardsccs.R
+++ b/R/standardsccs.R
@@ -98,6 +98,26 @@ standardsccs <- function(formula, indiv, astart, aend, aevent, adrug, aedrug, ex
   
   qq <- all.vars(as.formula(formula))[-c(which(all.vars(as.formula(formula))=="age"), which(all.vars(as.formula(formula))=="season"), which(all.vars(as.formula(formula))=="event"))]
   
+  # all.vars adds user entered reference levels to qq, causing an error when subsetting below
+  # need to remove these from qq
+  
+  # turn formula into a string character to be able to scrape out the ref levels
+  string_formula <- deparse1(formula)
+  
+  # identify all text following "ref = " and before a closing bracket
+  reg_expression_reflevels <- "ref\\s*=\\s*([^)]+)"
+  matching_reflevels <- gregexpr(reg_expression_reflevels, string_formula)
+  reflevels_long <- regmatches(string_formula, matching_reflevels)[[1]]
+  
+  # remove "ref = " from the result
+  reg_expression_reflevel_start <- "ref\\s*= "
+  reflevels <- gsub(reg_expression_reflevel_start, "", reflevels_long)
+  
+  # tidy up the qq string 
+  qq <- qq[! qq %in% reflevels]
+  
+  # qq now contains varnames only 
+  
   if (length(qq)==0) {
     cov <- cbind()
   }   else {


### PR DESCRIPTION
The standardsccs function takes a user specified model formula and uses this to subset the dataset before fitting the model. When there's at least one covariate, subsetting relies in part on column names, identified by applying the the `all.vars` function to the formula input. However, when reference levels in a model call are changed using `relevel`, `all.vars ` appears to assume that all string inputs are variable names. This means that supplying a reference level which is not a number throws an error: 

`event~mmr+relevel(age, ref = 1)` 

works fine 

```
my_level <- 1
event~mmr+relevel(age, ref = my_level)
```

results in 

> Error in `[.data.frame`(data, , cova) : undefined columns selected

Note, this only results in an error when there are covariates (as the string used to subset is only considered when there are covariates). The error makes it difficult to iteratively set different reference levels (for example, to select a reference group with the maximum number of events). I have explored two potential solutions to this: 

1. Use a subset function which just ignores columns that are not found, so instead of: 
`cov <- data.frame(data[, cova])`, we could have: 
`cov <- data.frame(subset(data, select = intersect(names(data), cova)))`
- Upside: 1 line of code 
- Downside: I was unsure whether this risked breaking other parts of the function, as there might be situations where we do want this to throw an error (for example, if the user has specified a variable that genuinely does not exist somewhere) 

2. Use regular expressions to identify everything that comes after ref = and before the closing bracket in relevel. Remove this from the character vector used to subset the data frame. 
- Upside: I think this is quite general, and would cover reference levels specified for multiple variables using different terms 
- Downside: the regular expressions are hard to read, and it's quite a few lines of code 

This PR proposes to implement [2]. I would really appreciate any thoughts on whether there's a different way of fixing this, as there may well be a simpler solution. I tested my edits using some of the inbuilt datasets and it seems to result in the expected results, but obviously there may be other use cases I've not thought of. I also wasn't sure if this would potentially affect other functions (eventdependex for example). 
